### PR TITLE
🌐 Traduction du message de soutien en anglais

### DIFF
--- a/src/views/FeedView.vue
+++ b/src/views/FeedView.vue
@@ -354,11 +354,11 @@
             </div>
             <!-- Supportive message when selecting the most negative mood -->
             <div v-if="selectedMood === 'very_sad'" class="mt-3 p-4 bg-red-50 border border-red-200 rounded-xl">
-              <p class="text-sm font-semibold text-red-800">On est là pour vous 💛</p>
+              <p class="text-sm font-semibold text-red-800">We're here for you 💛</p>
               <p class="text-xs text-red-700 mt-1">
-                Si vous vous sentez submergé(e), n'hésitez pas à en parler à une personne de confiance
-                ou à un professionnel. En cas d'urgence, contactez immédiatement les services d'urgence
-                de votre pays.
+                If you're feeling overwhelmed, don't hesitate to talk to someone you trust
+                or a professional. In case of emergency, contact emergency services
+                in your country immediately.
               </p>
             </div>
           </div>


### PR DESCRIPTION
- Message de soutien traduit de français vers anglais
- Affichage pour humeur 'very_sad' (Awful)
- Message: 'We're here for you 💛'
- Instructions d'urgence en anglais